### PR TITLE
#7 #8 update storage time, storage access, and response time inputs

### DIFF
--- a/app/_actions/formatBot.js
+++ b/app/_actions/formatBot.js
@@ -25,7 +25,6 @@ const schema = [
   "responseTime",
   "safetyTips",
   "storageAccess",
-  "storageTime",
   "vpnName",
 ];
 

--- a/app/_components/create.jsx
+++ b/app/_components/create.jsx
@@ -138,7 +138,6 @@ const valuesToUnregister = [
   "responseTime",
   "safetyTips",
   "storageAccess",
-  "storageTime",
   "vpnName",
 ];
 

--- a/app/_components/edit.jsx
+++ b/app/_components/edit.jsx
@@ -59,7 +59,6 @@ const valuesToUnregister = [
   "responseTime",
   "safetyTips",
   "storageAccess",
-  "storageTime",
   "vpnName",
 ];
 

--- a/app/_components/forms/helpdesk.jsx
+++ b/app/_components/forms/helpdesk.jsx
@@ -71,23 +71,6 @@ export const HelpdeskForm = ({ bot }) => {
       >
         <Input {...register("responseTime")} maxW={280} />
       </Field>
-      {/* FIXME remove storage time and access? */}
-      {/* <Field
-        errorText={!!errors?.storageTime && errors.storageTime.message}
-        helperText="How long the user's information will be stored in the system, in hours. We suggest XXX hours. Must be at least XX hours."
-        invalid={!!errors?.storageTime}
-        label="Data retention time"
-        marginTop={4}
-        required
-      >
-        <NumberInputRoot
-          min={1}
-          {...register("storageTime")}
-        >
-          <NumberInputLabel />
-          <NumberInputField />
-        </NumberInputRoot>
-      </Field> */}
       <Field
         errorText={!!errors?.storageAccess && errors.storageAccess.message}
         helperText="How long the users' information will be stored by your team, and who will have access to the information stored."

--- a/app/_components/forms/vpn.jsx
+++ b/app/_components/forms/vpn.jsx
@@ -113,38 +113,6 @@ export const VpnForm = ({ bot }) => {
       >
         <Input {...register("responseTime")} maxW={280} />
       </Field>
-      {/* FIXME do we need storage time? */}
-      {/* <Field
-        errorText={!!errors?.storageTime && errors.storageTime.message}
-        helperText="How long the user's information will be stored in the system, in hours. We suggest XX days, or XXX hours. Must be at least XX hours."
-        invalid={!!errors?.storageTime}
-        label="Data retention time"
-        marginTop={4}
-        required
-      >
-        <NumberInputRoot
-          min={1}
-          formatOptions={{
-            style: "unit",
-            unit: "hour",
-            unitDisplay: "long",
-          }}
-          {...register('storageTime')}
-        >
-          <NumberInputLabel />
-          <NumberInputField />
-        </NumberInputRoot>
-      </Field> */}
-      {/* <Field
-        errorText={!!errors?.vpnName && errors.vpnName.message}
-        helperText="Name of the VPN provider."
-        invalid={!!errors?.vpnName}
-        label="VPN provider name"
-        marginTop={4}
-        required
-      >
-        <Input {...register('vpnName')} />
-      </Field> */}
       <Field
         errorText={
           !!errors?.activationInstructions &&

--- a/app/_lib/forms.js
+++ b/app/_lib/forms.js
@@ -89,10 +89,15 @@ export const schema = yup.object({
     is: "helpdesk",
     then: () => yup.string().required("A referral person or place is required"),
   }),
-  storageTime: yup.number("Enter a number").when("botType", {
-    is: "helpdesk" || "vpn",
-    then: () => yup.number("Enter a number").optional(),
-  }),
+  responseTime: yup
+    .string("Enter a length of time, in hours, days or weeks etc.")
+    .when("botType", {
+      is: "helpdesk" || "vpn",
+      then: () =>
+        yup
+          .string("Enter a length of time, in hours, days or weeks etc.")
+          .optional(),
+    }),
   storageAccess: yup.string().when("botType", {
     is: "helpdesk",
     then: () => yup.string().optional(),

--- a/prisma/migrations/20250825150357_remove_storage_time/migration.sql
+++ b/prisma/migrations/20250825150357_remove_storage_time/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `storageTime` on the `Bot` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Bot" DROP COLUMN "storageTime";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,7 +81,6 @@ model Bot {
   referral               String?
   responseTime           String?
   storageAccess          String?
-  storageTime            Int?
   problems               Json[]
   vpnName                String?
   creatorId              String


### PR DESCRIPTION
The field `storageTime` was no longer being used, replaced by `storageAccess`. That has been updated and reflected in the code. In addition, the field for `responseTime` now has correct form validation, since that field is also in use.

To test, create and converse with a helpdesk bot successfully.

ETA: Remember to run `npx prisma migrate dev` to update migrations before attempting to create a new bot.