### PR TITLE
#68 add email address as option to registration and login workflow

### DIFF
--- a/app/_actions/register.js
+++ b/app/_actions/register.js
@@ -11,6 +11,7 @@ export const register = async (prevState, formData) => {
   const password = formData.get("password");
   const passwordConfirm = formData.get("passwordConfirm");
   const username = formData.get("username");
+  const email = formData.get("email");
 
   try {
     // validate form fields
@@ -32,16 +33,16 @@ export const register = async (prevState, formData) => {
       };
     }
 
-    const userFound = await prisma.user.findUnique({
+    const userFound = await prisma.user.findFirst({
       where: {
-        username,
+        OR: [{ email }, { username }],
       },
     });
 
     if (userFound) {
       return {
         error: {
-          username: "Username already exists.",
+          username: "A user with these credentials already exists.",
         },
       };
     }
@@ -79,6 +80,7 @@ export const register = async (prevState, formData) => {
 
     const user = await prisma.user.create({
       data: {
+        email,
         username,
         password: hashedPassword,
       },
@@ -90,7 +92,7 @@ export const register = async (prevState, formData) => {
 
     return {
       error: {
-        password: e.message,
+        general: e.message,
       },
     };
   } finally {

--- a/app/_components/login.js
+++ b/app/_components/login.js
@@ -79,16 +79,12 @@ export function LoginForm() {
         <Box marginLeft="auto" marginRight="auto" maxW={400}>
           <ToastSignUp />
           <Field.Root required>
-            <Field.Label>Username</Field.Label>
-            <Input name="username" placeholder="username.here" size="lg" />
+            <Field.Label>Username or email</Field.Label>
+            <Input name="username" size="lg" />
           </Field.Root>
           <Field.Root marginTop={4} required>
             <Field.Label>Password</Field.Label>
-            <PasswordInput
-              name="password"
-              placeholder="AVeryGoodPassword"
-              size="lg"
-            />
+            <PasswordInput name="password" size="lg" />
           </Field.Root>
           <Submit />
           <Text marginTop={8}>

--- a/app/_components/signup.js
+++ b/app/_components/signup.js
@@ -25,10 +25,24 @@ export function SignupForm() {
     <form action={formAction}>
       <Container marginLeft="auto" marginRight="auto" maxW="lg">
         <Field.Root invalid={state?.error} required>
-          <Field.Label>Enter invite code:</Field.Label>
+          <Field.Label>Enter your invite code</Field.Label>
           <PasswordInput name="code" placeholder="invite-code-here" size="lg" />
           {state?.error ? (
-            <Field.ErrorText>{state?.error?.code}</Field.ErrorText>
+            <Field.ErrorText>
+              {state?.error?.general || state?.error?.code}
+            </Field.ErrorText>
+          ) : null}
+        </Field.Root>
+        <Field.Root invalid={state?.error?.username} marginTop={12}>
+          <Field.Label>Enter your email address</Field.Label>
+          <Input name="email" placeholder="email@mail.org" size="lg" />
+          <Field.HelperText>
+            This field is optional. You may include an email for password
+            recovery. Password recovery will not be possible without an email
+            address.
+          </Field.HelperText>
+          {state?.error?.email ? (
+            <Field.ErrorText>{state.error.email}</Field.ErrorText>
           ) : null}
         </Field.Root>
         <Field.Root invalid={state?.error?.username} marginTop={12} required>

--- a/app/_lib/definitions.js
+++ b/app/_lib/definitions.js
@@ -2,6 +2,7 @@ import { object, string } from "yup";
 
 export const LoginSchema = object({
   username: string().required("Enter your username"),
+  email: string("Enter your email"),
   password: string()
     .min(8, "Password must contain at least 8 characters")
     .required("Enter your password"),

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -27,9 +27,12 @@ export default {
           const { username, password } = validatedFields;
 
           // 3. Insert the user into the database or verify if the user exists
-          user = await prisma.user.findUnique({
+          user = await prisma.user.findFirst({
             where: {
-              username: username,
+              OR: [
+                {username},
+                {email: username}
+              ]
             },
           });
 

--- a/auth.js
+++ b/auth.js
@@ -43,13 +43,6 @@ export const { handlers, signIn, signOut, newUser, auth } = NextAuth({
 
       return session;
     },
-    newUser(props) {
-      console.log('****************************');
-      console.log(props);
-      console.log('****************************');
-      
-      
-    },
   },
   credentials: {
     username: {},

--- a/prisma/migrations/20250825191439_add_optional_email_to_user/migration.sql
+++ b/prisma/migrations/20250825191439_add_optional_email_to_user/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[email]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "User_password_key";
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "email" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,7 +11,8 @@ generator client {
 model User {
   id        String    @id @default(cuid())
   username  String    @unique
-  password  String    @unique
+  email     String?   @unique
+  password  String
   accounts  Account[]
   sessions  Session[]
   bots      Bot[]
@@ -59,7 +60,7 @@ model VerificationToken {
 }
 
 model Bot {
-  id                     String    @id @default(cuid())
+  id                     String   @id @default(cuid())
   botType                String
   botName                String
   bitpartId              String   @unique


### PR DESCRIPTION
This PR adds an optional field for email on the registration page, and then allows a user to login with either their username or email address. Create a new user with and without an email address, and then login with and without an email address to test.

This does NOT include magic links for passwords.