### PR TITLE
Fixes #49, updating data rights for tipline bot

### DIFF
--- a/app/_components/drawer/tiplineMyData.js
+++ b/app/_components/drawer/tiplineMyData.js
@@ -7,18 +7,15 @@ import { Link, List, Text } from "@chakra-ui/react";
 export default function TiplineMyDataText() {
   return (
     <>
-      <Text>
-        This tipline does not ask you for any personal data except for a phone
-        number after you share your tip. You can choose to opt out by selecting
-        option 5.
-      </Text>
+      <Text>This tipline does not ask you for any personal data.</Text>
       <Text marginTop={4}>
         The tips you share is recorded & stored [WHERE?]
       </Text>
       <Text marginTop={4}>
         Personal data attached to your tip is any information that is visible on
-        your Signal profile (e.g. your profile nam, your phone number or
-        username if visible).
+        your Signal profile (e.g. your profile name, your phone number if you
+        choose to share or username if visible). Remember, you can adjust your
+        Signal profile settings to give you more anonymity.
       </Text>
       <Text marginTop={4}>We delete tips every [TIMEFRAME?]</Text>
       <Text marginTop={4}>

--- a/app/_components/forms/tipline.jsx
+++ b/app/_components/forms/tipline.jsx
@@ -36,7 +36,7 @@ export const TiplineForm = ({ bot }) => {
           defaultValue={
             bot
               ? bot.privacyPolicy
-              : `This tipline does not ask you for any personal data except for a phone number after you share your tip.\n\nThe tips you share is recorded & stored <WHERE?>\n\nPersonal data attached to your tip is any information that is visible on your Signal profile (e.g. your profile name, your phone number or username if visible).\n\nWe delete tips every <TIMEFRAME?>\n\nIf you would like your data deleted from our systems, please contact <ADD CONTACT METHOD>`
+              : `This tipline does not ask you for any personal data if you want to share a tip.\n\nPersonal data attached to your tip is any information that is visible on your Signal profile (e.g. your profile name, your phone number or username if visible).\n\nRemember, you can adjust your Signal profile settings such as your profile name and image, to give you more anonymity.\n\nAfter sharing a tip, you will be asked if you would like to be contacted, which you can refuse.\n\nIf you would like to be contacted you have the option to share your Signal username or phone number.\n\nTips are recorded & stored <WHERE?>.\n\nWe delete tips every <TIMEFRAME?>.`
           }
           {...register("privacyPolicy")}
         />


### PR DESCRIPTION
Fixes #49. To test, open the form to create a tipline bot an ensure the data rights text reflects the updated one as drafted in the issue. 