### PR TITLE
Change confirmation language when deleting bots

### DIFF
--- a/app/_components/botsList.jsx
+++ b/app/_components/botsList.jsx
@@ -48,12 +48,9 @@ export default function BotsList({ username }) {
         )
       ) {
         await deleteBot(id, phone, username);
-        await fetchBots();
-        setIsFetching(false);
-      } else {
-        await fetchBots();
-        setIsFetching(false);
       }
+      await fetchBots();
+      setIsFetching(false);
     } catch (error) {
       console.log("error: ", error);
     }


### PR DESCRIPTION
Fixes #98 -- added language to remind users to unlink the device from the bot and added option in the window  pop up to cancel the delete action. To test, try deleting a bot you've created it. 